### PR TITLE
Invoking setImmediate() via another binding is an error in IE.

### DIFF
--- a/source/index.md
+++ b/source/index.md
@@ -26,9 +26,9 @@ var isNode = typeof process !== "undefined" &&
 if (isNode) {
   asap = process.nextTick;
 } else if (typeof setImmediate !== "undefined") {
-  asap = setImmediate;
+  asap = function(fn) { setImmediate(fn) };
 } else {
-  asap = setTimeout;
+  asap = function(fn) { setTimeout(fn, 0) };
 }
 
 export default asap;
@@ -75,9 +75,9 @@ var isNode = typeof process !== "undefined" &&
 if (isNode) {
   asap = process.nextTick;
 } else if (typeof setImmediate !== "undefined") {
-  asap = setImmediate;
+  asap = function(fn) { setImmediate(fn) };
 } else {
-  asap = setTimeout;
+  asap = function(fn) { setTimeout(fn, 0) };
 }
 
 export default asap;


### PR DESCRIPTION
In Internet explorer, you cannot do this:

``` js
var asap = setImmediate;
asap(function() { /* ... */ });
```

IE will throw an error if you do this. You have to invoke `setImmediate()` through its original binding, so we need to explicitly wrap it rather than simply assigning it to a variable.
